### PR TITLE
Fix: multiple subgroups not work

### DIFF
--- a/src/FastRoute.php
+++ b/src/FastRoute.php
@@ -416,7 +416,7 @@ EOT;
                 foreach ($group->items as $index => $item) {
                     if ($item instanceof Group) {
                         $this->injectGroup($item, $r);
-                        return;
+                        continue;
                     }
 
                     $modifiedItem = $item->pattern($group->getPrefix() . $item->getPattern());
@@ -431,7 +431,7 @@ EOT;
 
                     // Skip feeding FastRoute collector if valid cached data was already loaded
                     if ($this->hasCache) {
-                        return;
+                        continue;
                     }
 
                     $r->addRoute($item->getMethods(), $item->getPattern(), $modifiedItem->getPattern());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 

```
$router = ... 
    
$router->addGroup('/api', static function (RouteCollectorInterface $r) {
    $r->addRoute(Route::get('/comments'));
    $r->addGroup('/posts', static function (RouteCollectorInterface $r) {
        $r->addRoute(Route::get('/list'));
    });
    $r->addGroup('/comments', static function (RouteCollectorInterface $r) {
        $r->addRoute(Route::get('/list'));
    });
});
```
the loop stops at the first group found, and the remaining groups and routers are ignored
and when you try to go to the url `api/comments/list` returns 404