### PR TITLE
Fix: keep query string when generating from current route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.2 under development
 
-- Bug #107: Fix: keep query string when generating from current route (@rustamwin)
+- Bug #107: Keep query string when generating from current route (@rustamwin)
 
 ## 1.1.1 June 28, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Enh #103: Add support for `psr/simple-cache` version `^2.0|^3.0` (@vjik)
 
 ## 1.1.0 June 27, 2022
+
 - Chg #102: Update `yiisoft/router` version to `^1.1` (@rustamwin)
 - Enh #100: Add support for multiple route hosts (@Gerych1984)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,13 @@
 
 ## 1.1.2 under development
 
-- no changes in this release.
+- Bug #107: Fix: keep query string when generating from current route (@rustamwin)
 
 ## 1.1.1 June 28, 2022
 
 - Enh #103: Add support for `psr/simple-cache` version `^2.0|^3.0` (@vjik)
 
 ## 1.1.0 June 27, 2022
-
 - Chg #102: Update `yiisoft/router` version to `^1.1` (@rustamwin)
 - Enh #100: Add support for multiple route hosts (@Gerych1984)
 

--- a/src/UrlGenerator.php
+++ b/src/UrlGenerator.php
@@ -126,9 +126,7 @@ final class UrlGenerator implements UrlGeneratorInterface
             }
 
             if ($this->currentRoute !== null && $this->currentRoute->getUri() !== null) {
-                return $this->currentRoute
-                    ->getUri()
-                    ->getPath();
+                return $this->currentRoute->getUri()->getPath();
             }
 
             throw new RuntimeException('Current route is not detected.');

--- a/src/UrlGenerator.php
+++ b/src/UrlGenerator.php
@@ -136,10 +136,13 @@ final class UrlGenerator implements UrlGeneratorInterface
             throw new RuntimeException('Current route is not detected.');
         }
 
+        parse_str($this->currentRoute->getUri()->getQuery(), $queryParameters);
+
         /** @psalm-suppress PossiblyNullArgument Checked route name on null above. */
         return $this->generate(
             $this->currentRoute->getName(),
-            array_merge($this->currentRoute->getArguments(), $replacedArguments)
+            array_merge($this->currentRoute->getArguments(), $replacedArguments),
+            $queryParameters,
         );
     }
 

--- a/src/UrlGenerator.php
+++ b/src/UrlGenerator.php
@@ -95,8 +95,6 @@ final class UrlGenerator implements UrlGeneratorInterface
         string $scheme = null,
         string $host = null
     ): string {
-        $arguments = array_map('\strval', $arguments);
-
         $url = $this->generate($name, $arguments, $queryParameters);
         $route = $this->routeCollection->getRoute($name);
         $uri = $this->currentRoute && $this->currentRoute->getUri() !== null ? $this->currentRoute->getUri() : null;

--- a/src/UrlGenerator.php
+++ b/src/UrlGenerator.php
@@ -136,7 +136,10 @@ final class UrlGenerator implements UrlGeneratorInterface
             throw new RuntimeException('Current route is not detected.');
         }
 
-        parse_str($this->currentRoute->getUri()->getQuery(), $queryParameters);
+        $queryParameters = [];
+        if ($this->currentRoute->getUri() !== null) {
+            parse_str($this->currentRoute->getUri()->getQuery(), $queryParameters);
+        }
 
         /** @psalm-suppress PossiblyNullArgument Checked route name on null above. */
         return $this->generate(

--- a/tests/UrlGeneratorTest.php
+++ b/tests/UrlGeneratorTest.php
@@ -658,6 +658,68 @@ final class UrlGeneratorTest extends TestCase
     public function testGenerateFromCurrent(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/en/home/index');
+        $route = Route::get('/home/index')->name('index');
+
+        $currentRoute = new CurrentRoute();
+        $currentRoute->setUri($request->getUri());
+        $currentRoute->setRouteWithArguments($route, []);
+        $urlGenerator = $this->createUrlGenerator([$route], $currentRoute);
+
+        $url = $urlGenerator->generateFromCurrent([]);
+
+        $this->assertEquals('/home/index', $url);
+    }
+
+    public function testGenerateFromCurrentWithRouteArguments(): void
+    {
+        $request = new ServerRequest('GET', 'http://example.com/en/home/index');
+        $route = Route::get('/{_locale}/home/index')->name('index');
+
+        $currentRoute = new CurrentRoute();
+        $currentRoute->setUri($request->getUri());
+        $currentRoute->setRouteWithArguments($route, ['_locale' => 'en']);
+        $urlGenerator = $this->createUrlGenerator([$route], $currentRoute);
+
+        $url = $urlGenerator->generateFromCurrent([]);
+
+        $this->assertEquals('/en/home/index', $url);
+    }
+
+    public function testGenerateFromCurrentWithDefaultArguments(): void
+    {
+        $request = new ServerRequest('GET', 'http://example.com/en/home/index');
+        $route = Route::get('/{_locale}/home/index')->name('index');
+
+        $currentRoute = new CurrentRoute();
+        $currentRoute->setUri($request->getUri());
+        $currentRoute->setRouteWithArguments($route, []);
+        $urlGenerator = $this->createUrlGenerator([$route], $currentRoute);
+        $urlGenerator->setDefaultArgument('_locale', 'uz');
+
+        $url = $urlGenerator->generateFromCurrent([]);
+
+        $this->assertEquals('/uz/home/index', $url);
+    }
+
+    public function testGenerateFromCurrentWithDefaultArgumentsAndRouteArguments(): void
+    {
+        $request = new ServerRequest('GET', 'http://example.com/en/home/index');
+        $route = Route::get('/{_locale}/home/index')->name('index');
+
+        $currentRoute = new CurrentRoute();
+        $currentRoute->setUri($request->getUri());
+        $currentRoute->setRouteWithArguments($route, ['_locale' => 'en']);
+        $urlGenerator = $this->createUrlGenerator([$route], $currentRoute);
+        $urlGenerator->setDefaultArgument('_locale', 'uz');
+
+        $url = $urlGenerator->generateFromCurrent([]);
+
+        $this->assertEquals('/en/home/index', $url);
+    }
+
+    public function testGenerateFromCurrentWithDefaultArgumentsAndReplacedArguments(): void
+    {
+        $request = new ServerRequest('GET', 'http://example.com/en/home/index');
         $route = Route::get('/{_locale}/home/index')->name('index');
 
         $currentRoute = new CurrentRoute();

--- a/tests/UrlGeneratorTest.php
+++ b/tests/UrlGeneratorTest.php
@@ -702,7 +702,7 @@ final class UrlGeneratorTest extends TestCase
                 Route::get('/{_locale}/home/index')->name('index'),
                 ['_locale' => 'en'],
                 ['_locale', 'en'],
-                []
+                [],
             ],
             [
                 'http://example.com/en/home/index',
@@ -711,7 +711,7 @@ final class UrlGeneratorTest extends TestCase
                 ['_locale' => 'en'],
                 ['_locale', 'uz'],
                 ['_locale' => 'ru'],
-        ],
+            ],
             [
                 'http://example.com/en/home/index?test=1',
                 '/ru/home/index?test=1',
@@ -719,7 +719,7 @@ final class UrlGeneratorTest extends TestCase
                 ['_locale' => 'en'],
                 ['_locale', 'uz'],
                 ['_locale' => 'ru'],
-            ]
+            ],
         ];
     }
 

--- a/tests/UrlGeneratorTest.php
+++ b/tests/UrlGeneratorTest.php
@@ -655,39 +655,25 @@ final class UrlGeneratorTest extends TestCase
         $this->assertEquals('http://example.com/ru/home/index', $url);
     }
 
-    public function testGenerateFromCurrent(): void
-    {
-        $request = new ServerRequest('GET', 'http://example.com/en/home/index');
-        $route = Route::get('/home/index')->name('index');
-
-        $currentRoute = new CurrentRoute();
-        $currentRoute->setUri($request->getUri());
-        $currentRoute->setRouteWithArguments($route, []);
-        $urlGenerator = $this->createUrlGenerator([$route], $currentRoute);
-
-        $url = $urlGenerator->generateFromCurrent([]);
-
-        $this->assertEquals('/home/index', $url);
-    }
-
-    public function testGenerateFromCurrentWithRouteArguments(): void
-    {
-        $request = new ServerRequest('GET', 'http://example.com/en/home/index');
-        $route = Route::get('/{_locale}/home/index')->name('index');
-
-        $currentRoute = new CurrentRoute();
-        $currentRoute->setUri($request->getUri());
-        $currentRoute->setRouteWithArguments($route, ['_locale' => 'en']);
-        $urlGenerator = $this->createUrlGenerator([$route], $currentRoute);
-
-        $url = $urlGenerator->generateFromCurrent([]);
-
-        $this->assertEquals('/en/home/index', $url);
-    }
-
     private function currentRouteArgumentsProvider(): array
     {
         return [
+            [
+                'http://example.com/en/home/index',
+                '/home/index',
+                Route::get('/home/index')->name('index'),
+                [],
+                [],
+                [],
+            ],
+            [
+                'http://example.com/en/home/index',
+                '/en/home/index',
+                Route::get('/{_locale}/home/index')->name('index'),
+                ['_locale' => 'en'],
+                [],
+                [],
+            ],
             [
                 'http://example.com/en/home/index',
                 '/uz/home/index',

--- a/tests/UrlGeneratorTest.php
+++ b/tests/UrlGeneratorTest.php
@@ -187,7 +187,7 @@ final class UrlGeneratorTest extends TestCase
     {
         $routes = [
             Route::get('/test/{name}')
-                ->name('test'),
+                 ->name('test'),
         ];
 
         $url = $this
@@ -200,7 +200,7 @@ final class UrlGeneratorTest extends TestCase
     {
         $routes = [
             Route::get('/test/{name}')
-                ->name('test'),
+                 ->name('test'),
         ];
 
         $url = $this
@@ -213,7 +213,7 @@ final class UrlGeneratorTest extends TestCase
     {
         $routes = [
             Route::get('/test/{name}')
-                ->name('test'),
+                 ->name('test'),
         ];
 
         $url = $this
@@ -226,7 +226,7 @@ final class UrlGeneratorTest extends TestCase
     {
         $routes = [
             Route::get('/test/{name}')
-                ->name('test'),
+                 ->name('test'),
         ];
 
         $url = $this
@@ -239,8 +239,8 @@ final class UrlGeneratorTest extends TestCase
     {
         $routes = [
             Route::get('/[{name}]')
-                ->name('defaults')
-                ->defaults(['name' => 'default']),
+                 ->name('defaults')
+                 ->defaults(['name' => 'default']),
         ];
 
         $url = $this
@@ -253,8 +253,8 @@ final class UrlGeneratorTest extends TestCase
     {
         $routes = [
             Route::get('/[{name}]')
-                ->name('defaults')
-                ->defaults(['name' => 'default']),
+                 ->name('defaults')
+                 ->defaults(['name' => 'default']),
         ];
 
         $url = $this
@@ -267,8 +267,8 @@ final class UrlGeneratorTest extends TestCase
     {
         $routes = [
             Route::get('/{name}')
-                ->name('defaults')
-                ->defaults(['name' => 'default']),
+                 ->name('defaults')
+                 ->defaults(['name' => 'default']),
         ];
 
         $this->expectExceptionMessage('Route `defaults` expects at least argument values for [name], but received []');
@@ -284,8 +284,8 @@ final class UrlGeneratorTest extends TestCase
     {
         $routes = [
             Route::get('/home/index')
-                ->name('index')
-                ->host('http://test.com'),
+                 ->name('index')
+                 ->host('http://test.com'),
         ];
         $url = $this
             ->createUrlGenerator($routes)
@@ -301,8 +301,8 @@ final class UrlGeneratorTest extends TestCase
     {
         $routes = [
             Route::get('/home/index')
-                ->name('index')
-                ->host('http://test.com'),
+                 ->name('index')
+                 ->host('http://test.com'),
         ];
         $url = $this
             ->createUrlGenerator($routes)
@@ -318,8 +318,8 @@ final class UrlGeneratorTest extends TestCase
     {
         $routes = [
             Route::get('/home/index')
-                ->name('index')
-                ->host('http://test.com'),
+                 ->name('index')
+                 ->host('http://test.com'),
         ];
         $url = $this
             ->createUrlGenerator($routes)
@@ -368,8 +368,8 @@ final class UrlGeneratorTest extends TestCase
     {
         $routes = [
             Route::get('/home/index')
-                ->name('index')
-                ->host('http://test.com'),
+                 ->name('index')
+                 ->host('http://test.com'),
         ];
         $url = $this
             ->createUrlGenerator($routes)
@@ -385,8 +385,8 @@ final class UrlGeneratorTest extends TestCase
     {
         $routes = [
             Route::get('/home/index')
-                ->name('index')
-                ->host('http://test.com/'),
+                 ->name('index')
+                 ->host('http://test.com/'),
         ];
         $url = $this
             ->createUrlGenerator($routes)
@@ -443,8 +443,8 @@ final class UrlGeneratorTest extends TestCase
         $request = new ServerRequest('GET', 'http://test.com/home/index');
         $routes = [
             Route::get('/home/index')
-                ->name('index')
-                ->host('//test.com'),
+                 ->name('index')
+                 ->host('//test.com'),
         ];
 
         $currentRoute = new CurrentRoute();
@@ -465,8 +465,8 @@ final class UrlGeneratorTest extends TestCase
         $request = new ServerRequest('GET', 'http://test.com/home/index');
         $routes = [
             Route::get('/home/index')
-                ->name('index')
-                ->host('//mysite.com'),
+                 ->name('index')
+                 ->host('//mysite.com'),
         ];
 
         $currentRoute = new CurrentRoute();
@@ -483,11 +483,11 @@ final class UrlGeneratorTest extends TestCase
         $request = new ServerRequest('GET', 'http://test.com/home/index');
         $routes = [
             Route::get('/home/index')
-                ->name('index')
-                ->host('http://test.com'),
+                 ->name('index')
+                 ->host('http://test.com'),
             Route::get('/home/view')
-                ->name('view')
-                ->host('test.com'),
+                 ->name('view')
+                 ->host('test.com'),
         ];
 
         $currentRoute = new CurrentRoute();
@@ -508,8 +508,8 @@ final class UrlGeneratorTest extends TestCase
         $request = new ServerRequest('GET', 'http://test.com/home/index');
         $routes = [
             Route::get('/home/index')
-                ->name('index')
-                ->host('//mysite.com'),
+                 ->name('index')
+                 ->host('//mysite.com'),
         ];
 
         $currentRoute = new CurrentRoute();
@@ -560,8 +560,8 @@ final class UrlGeneratorTest extends TestCase
         $request = new ServerRequest('GET', 'http://example.com/home/index');
         $routes = [
             Route::get('/home/index')
-                ->name('index')
-                ->host('example.com'),
+                 ->name('index')
+                 ->host('example.com'),
         ];
 
         $currentRoute = new CurrentRoute();
@@ -685,68 +685,68 @@ final class UrlGeneratorTest extends TestCase
         $this->assertEquals('/en/home/index', $url);
     }
 
-    public function testGenerateFromCurrentWithDefaultArguments(): void
+    private function currentRouteArgumentsProvider(): array
     {
-        $request = new ServerRequest('GET', 'http://example.com/en/home/index');
-        $route = Route::get('/{_locale}/home/index')->name('index');
-
-        $currentRoute = new CurrentRoute();
-        $currentRoute->setUri($request->getUri());
-        $currentRoute->setRouteWithArguments($route, []);
-        $urlGenerator = $this->createUrlGenerator([$route], $currentRoute);
-        $urlGenerator->setDefaultArgument('_locale', 'uz');
-
-        $url = $urlGenerator->generateFromCurrent([]);
-
-        $this->assertEquals('/uz/home/index', $url);
+        return [
+            [
+                'http://example.com/en/home/index',
+                '/uz/home/index',
+                Route::get('/{_locale}/home/index')->name('index'),
+                [],
+                ['_locale', 'uz'],
+                [],
+            ],
+            [
+                'http://example.com/en/home/index',
+                '/en/home/index',
+                Route::get('/{_locale}/home/index')->name('index'),
+                ['_locale' => 'en'],
+                ['_locale', 'en'],
+                []
+            ],
+            [
+                'http://example.com/en/home/index',
+                '/ru/home/index',
+                Route::get('/{_locale}/home/index')->name('index'),
+                ['_locale' => 'en'],
+                ['_locale', 'uz'],
+                ['_locale' => 'ru'],
+        ],
+            [
+                'http://example.com/en/home/index?test=1',
+                '/ru/home/index?test=1',
+                Route::get('/{_locale}/home/index')->name('index'),
+                ['_locale' => 'en'],
+                ['_locale', 'uz'],
+                ['_locale' => 'ru'],
+            ]
+        ];
     }
 
-    public function testGenerateFromCurrentWithDefaultArgumentsAndRouteArguments(): void
-    {
-        $request = new ServerRequest('GET', 'http://example.com/en/home/index');
-        $route = Route::get('/{_locale}/home/index')->name('index');
+    /**
+     * @dataProvider currentRouteArgumentsProvider
+     */
+    public function testGenerateFromCurrentWithArguments(
+        string $uri,
+        string $expectedUrl,
+        Route $route,
+        array $routeArguments,
+        array $defaultArgument,
+        array $replacedArguments
+    ): void {
+        $request = new ServerRequest('GET', $uri);
 
         $currentRoute = new CurrentRoute();
         $currentRoute->setUri($request->getUri());
-        $currentRoute->setRouteWithArguments($route, ['_locale' => 'en']);
+        $currentRoute->setRouteWithArguments($route, $routeArguments);
         $urlGenerator = $this->createUrlGenerator([$route], $currentRoute);
-        $urlGenerator->setDefaultArgument('_locale', 'uz');
+        if ($defaultArgument !== []) {
+            $urlGenerator->setDefaultArgument($defaultArgument[0], $defaultArgument[1]);
+        }
 
-        $url = $urlGenerator->generateFromCurrent([]);
+        $url = $urlGenerator->generateFromCurrent($replacedArguments);
 
-        $this->assertEquals('/en/home/index', $url);
-    }
-
-    public function testGenerateFromCurrentWithDefaultArgumentsAndReplacedArguments(): void
-    {
-        $request = new ServerRequest('GET', 'http://example.com/en/home/index');
-        $route = Route::get('/{_locale}/home/index')->name('index');
-
-        $currentRoute = new CurrentRoute();
-        $currentRoute->setUri($request->getUri());
-        $currentRoute->setRouteWithArguments($route, ['_locale' => 'en']);
-        $urlGenerator = $this->createUrlGenerator([$route], $currentRoute);
-        $urlGenerator->setDefaultArgument('_locale', 'uz');
-
-        $url = $urlGenerator->generateFromCurrent(['_locale' => 'ru']);
-
-        $this->assertEquals('/ru/home/index', $url);
-    }
-
-    public function testGenerateFromCurrentWithQueryString(): void
-    {
-        $request = new ServerRequest('GET', 'http://example.com/en/home/index?test=1');
-        $route = Route::get('/{_locale}/home/index')->name('index');
-
-        $currentRoute = new CurrentRoute();
-        $currentRoute->setUri($request->getUri());
-        $currentRoute->setRouteWithArguments($route, ['_locale' => 'en']);
-        $urlGenerator = $this->createUrlGenerator([$route], $currentRoute);
-        $urlGenerator->setDefaultArgument('_locale', 'uz');
-
-        $url = $urlGenerator->generateFromCurrent(['_locale' => 'ru']);
-
-        $this->assertEquals('/ru/home/index?test=1', $url);
+        $this->assertEquals($expectedUrl, $url);
     }
 
     public function testGenerateFromCurrentWithFallbackRoute(): void

--- a/tests/UrlGeneratorTest.php
+++ b/tests/UrlGeneratorTest.php
@@ -671,6 +671,22 @@ final class UrlGeneratorTest extends TestCase
         $this->assertEquals('/ru/home/index', $url);
     }
 
+    public function testGenerateFromCurrentWithQueryString(): void
+    {
+        $request = new ServerRequest('GET', 'http://example.com/en/home/index?test=1');
+        $route = Route::get('/{_locale}/home/index')->name('index');
+
+        $currentRoute = new CurrentRoute();
+        $currentRoute->setUri($request->getUri());
+        $currentRoute->setRouteWithArguments($route, ['_locale' => 'en']);
+        $urlGenerator = $this->createUrlGenerator([$route], $currentRoute);
+        $urlGenerator->setDefaultArgument('_locale', 'uz');
+
+        $url = $urlGenerator->generateFromCurrent(['_locale' => 'ru']);
+
+        $this->assertEquals('/ru/home/index?test=1', $url);
+    }
+
     public function testGenerateFromCurrentWithFallbackRoute(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/en/home/index');

--- a/tests/UrlGeneratorTest.php
+++ b/tests/UrlGeneratorTest.php
@@ -655,7 +655,7 @@ final class UrlGeneratorTest extends TestCase
         $this->assertEquals('http://example.com/ru/home/index', $url);
     }
 
-    private function currentRouteArgumentsProvider(): array
+    public function currentRouteArgumentsProvider(): array
     {
         return [
             [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -