### PR TITLE
Fix #133, #134: Don't add not substituted arguments and empty values to query string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 3.0.1 under development
 
-- no changes in this release.
+- Bug #133: Don't add not substituted arguments to a query string (@rustamwin)
+- Bug #134: Don't add query string if it's empty (@rustamwin)
 
 ## 3.0.0 February 17, 2023
 

--- a/src/UrlGenerator.php
+++ b/src/UrlGenerator.php
@@ -254,7 +254,7 @@ final class UrlGenerator implements UrlGeneratorInterface
             }
         }
 
-        // All required arguments are availgit logable.
+        // All required arguments are available.
         return [];
     }
 
@@ -297,10 +297,11 @@ final class UrlGenerator implements UrlGeneratorInterface
 
         $path = str_replace('//', '/', $path);
 
-        return $path . (
-            $notSubstitutedArguments !== [] || $queryParameters !== [] ?
-                '?' . http_build_query(array_merge($notSubstitutedArguments, $queryParameters))
-                : ''
-        );
+        $queryString = '';
+        if (!empty($notSubstitutedArguments) || !empty($queryParameters)) {
+            $queryString = http_build_query(array_merge($notSubstitutedArguments, $queryParameters));
+        }
+
+        return $path . (!empty($queryString) ? '?' . $queryString : '');
     }
 }

--- a/src/UrlGenerator.php
+++ b/src/UrlGenerator.php
@@ -298,8 +298,8 @@ final class UrlGenerator implements UrlGeneratorInterface
         $path = str_replace('//', '/', $path);
 
         $queryString = '';
-        if (!empty($notSubstitutedArguments) || !empty($queryParameters)) {
-            $queryString = http_build_query(array_merge($notSubstitutedArguments, $queryParameters));
+        if (!empty($queryParameters)) {
+            $queryString = http_build_query($queryParameters);
         }
 
         return $path . (!empty($queryString) ? '?' . $queryString : '');

--- a/tests/UrlGeneratorTest.php
+++ b/tests/UrlGeneratorTest.php
@@ -866,7 +866,7 @@ final class UrlGeneratorTest extends TestCase
     {
         $rootGroup = Group::create()->routes(...$routes);
         $collector = new RouteCollector();
-        $collector->addRoute($rootGroup);
+        $collector->addGroup($rootGroup);
         return new RouteCollection($collector);
     }
 }

--- a/tests/UrlGeneratorTest.php
+++ b/tests/UrlGeneratorTest.php
@@ -196,6 +196,19 @@ final class UrlGeneratorTest extends TestCase
         $this->assertEquals('/test/post?id=12&sort=asc', $url);
     }
 
+    public function testQueryParametersAddedAsQueryStringWithEmptyValues(): void
+    {
+        $routes = [
+            Route::get('/test/{name}')
+                 ->name('test'),
+        ];
+
+        $url = $this
+            ->createUrlGenerator($routes)
+            ->generate('test', ['name' => 'post'], ['id' => null]);
+        $this->assertEquals('/test/post', $url);
+    }
+
     public function testExtraArgumentsAddedAsQueryString(): void
     {
         $routes = [
@@ -866,7 +879,7 @@ final class UrlGeneratorTest extends TestCase
     {
         $rootGroup = Group::create()->routes(...$routes);
         $collector = new RouteCollector();
-        $collector->addGroup($rootGroup);
+        $collector->addRoute($rootGroup);
         return new RouteCollection($collector);
     }
 }

--- a/tests/UrlGeneratorTest.php
+++ b/tests/UrlGeneratorTest.php
@@ -209,19 +209,6 @@ final class UrlGeneratorTest extends TestCase
         $this->assertEquals('/test/post', $url);
     }
 
-    public function testExtraArgumentsAddedAsQueryString(): void
-    {
-        $routes = [
-            Route::get('/test/{name}')
-                 ->name('test'),
-        ];
-
-        $url = $this
-            ->createUrlGenerator($routes)
-            ->generate('test', ['name' => 'post', 'id' => 12, 'sort' => 'asc']);
-        $this->assertEquals('/test/post?id=12&sort=asc', $url);
-    }
-
     public function testQueryParametersOverrideExtraArguments(): void
     {
         $routes = [
@@ -235,7 +222,7 @@ final class UrlGeneratorTest extends TestCase
         $this->assertEquals('/test/post?id=12&sort=asc', $url);
     }
 
-    public function testQueryParametersMergedWithExtraArguments(): void
+    public function testNotSubstitutedArgumentsRemove(): void
     {
         $routes = [
             Route::get('/test/{name}')
@@ -245,7 +232,7 @@ final class UrlGeneratorTest extends TestCase
         $url = $this
             ->createUrlGenerator($routes)
             ->generate('test', ['name' => 'post', 'id' => 11], ['sort' => 'asc']);
-        $this->assertEquals('/test/post?id=11&sort=asc', $url);
+        $this->assertEquals('/test/post?sort=asc', $url);
     }
 
     public function testDefaultNotUsedForOptionalArgument(): void

--- a/tests/UrlMatcherTest.php
+++ b/tests/UrlMatcherTest.php
@@ -491,7 +491,7 @@ final class UrlMatcherTest extends TestCase
     {
         $rootGroup = Group::create()->routes(...$routes);
         $collector = new RouteCollector();
-        $collector->addRoute($rootGroup);
+        $collector->addGroup($rootGroup);
         return new UrlMatcher(new RouteCollection($collector), $cache, ['cache_key' => 'route-cache']);
     }
 }

--- a/tests/UrlMatcherTest.php
+++ b/tests/UrlMatcherTest.php
@@ -491,7 +491,7 @@ final class UrlMatcherTest extends TestCase
     {
         $rootGroup = Group::create()->routes(...$routes);
         $collector = new RouteCollector();
-        $collector->addGroup($rootGroup);
+        $collector->addRoute($rootGroup);
         return new UrlMatcher(new RouteCollection($collector), $cache, ['cache_key' => 'route-cache']);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #133 #134 