### PR TITLE
Fix merging of query parameters with non-substituted arguments in `UrlGenerator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 4.0.1 under development
 
-- no changes in this release.
+- Bug #159: Fix merging of query parameters with non-substituted arguments in `UrlGenerator` (@vjik)
 
 ## 4.0.0 February 25, 2025
 

--- a/src/UrlGenerator.php
+++ b/src/UrlGenerator.php
@@ -286,6 +286,7 @@ final class UrlGenerator implements UrlGeneratorInterface
     private function generatePath(array $arguments, array $queryParameters, array $parts, ?string $hash): string
     {
         $path = $this->getUriPrefix();
+        $notSubstitutedArguments = $arguments;
 
         foreach ($parts as $part) {
             if (is_string($part)) {
@@ -312,11 +313,13 @@ final class UrlGenerator implements UrlGeneratorInterface
                     ? rawurlencode($arguments[$part[0]])
                     : urlencode($arguments[$part[0]]);
             }
+            unset($notSubstitutedArguments[$part[0]]);
         }
 
         $path = str_replace('//', '/', $path);
 
         $queryString = '';
+        $queryParameters += $notSubstitutedArguments;
         if (!empty($queryParameters)) {
             $queryString = http_build_query($queryParameters);
         }

--- a/tests/UrlGeneratorTest.php
+++ b/tests/UrlGeneratorTest.php
@@ -211,8 +211,7 @@ final class UrlGeneratorTest extends TestCase
     public function testQueryParametersOverrideExtraArguments(): void
     {
         $routes = [
-            Route::get('/test/{name}')
-                ->name('test'),
+            Route::get('/test/{name}')->name('test'),
         ];
 
         $url = $this
@@ -221,17 +220,16 @@ final class UrlGeneratorTest extends TestCase
         $this->assertEquals('/test/post?id=12&sort=asc', $url);
     }
 
-    public function testNotSubstitutedArgumentsRemove(): void
+    public function testQueryParametersMergedWithExtraArguments(): void
     {
         $routes = [
-            Route::get('/test/{name}')
-                ->name('test'),
+            Route::get('/test/{name}')->name('test'),
         ];
 
         $url = $this
             ->createUrlGenerator($routes)
             ->generate('test', ['name' => 'post', 'id' => 11], ['sort' => 'asc']);
-        $this->assertEquals('/test/post?sort=asc', $url);
+        $this->assertEquals('/test/post?sort=asc&id=11', $url);
     }
 
     public function testDefaultNotUsedForOptionalArgument(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
